### PR TITLE
Add CODEOWNERS to the repository

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+# These owners will be the default owners for everything in
+# the repo. People listed below will be requested for review
+# when someone opens a pull request.
+* @aglover @bobcatfish @ahpook @fdegir @fuqiao123 @MarckK @pritianka @zxiiro @tracymiranda @wavell


### PR DESCRIPTION
CODEOWNERS file makes who can review and submit PRs visible to everyone who
looks at the repository and contributes.

The information in CODEOWNERS could be seen as duplicate to the members list
but this is a small cost comparing to the benefits it has in addition to making
reviewers visible. The most important benefit is that everyone in this file is
automatically requested for review for the PRs opened for the repository,
removing the need to figure it out and manually add them. [0]

[0] https://help.github.com/en/articles/about-code-owners

Closes: #11