### PR TITLE
Add meetings file for event driven CICD workstream

### DIFF
--- a/workstreams/event_driven_cicd/meetings.md
+++ b/workstreams/event_driven_cicd/meetings.md
@@ -1,0 +1,1 @@
+# Meeting notes for event driven CI/CD workstream


### PR DESCRIPTION
I'd like to add a folder for workstreams in general and for the workstream 'event driven CICD' in particular. My intention is to keep meeting notes in hackmd for this workstream.