### PR TITLE
Add new members of the SIG to CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
 # These owners will be the default owners for everything in
 # the repo. People listed below will be requested for review
 # when someone opens a pull request.
-* @aglover @bobcatfish @ahpook @fdegir @fuqiao123 @MarckK @pritianka @zxiiro @tracymiranda @wavell
+* @aglover @bobcatfish @ahpook @fdegir @fuqiao123 @MarckK @pritianka @zxiiro @tracymiranda @wavell @agrimmer @chhsia0 @ravilach


### PR DESCRIPTION
Andreas Grimmer, Chun-Hung Hsiao, and Ravi Lachhman joined to the
SIG as new members so updating CODEOWNERS file to reflect this.