### PR TITLE
Correct meeting time

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ SIG Interoperability also uses Slack for additional collaboration opportunities.
 
 ## Meetings
 
-SIG Interoperability meets every even week on Thursdays at 15:00UTC. (*See your timezone [here](https://time.is/1500_in_UTC)*).
+SIG Interoperability meets every even week on Thursdays at 17:00UTC. (*See your timezone [here](https://time.is/1700_in_UTC)*).
 
 * Meeting agenda and minutes: [docs/meetings.md](docs/meetings.md)
 * Zoom Bridge: https://zoom.us/j/827082528

--- a/docs/meetings.md
+++ b/docs/meetings.md
@@ -19,7 +19,7 @@
 ## Logistics
 
 * Meeting notes on HackMD.io: https://hackmd.io/@cdf-sig-interoperability/ry3TTB5DL
-* When: every even week on Thursdays at 15:00UTC (*See your timezone [here](https://time.is/1500_in_UTC)*).
+* When: every even week on Thursdays at 17:00UTC (*See your timezone [here](https://time.is/1500_in_UTC)*).
 * Zoom Bridge: https://zoom.us/j/827082528
 * Zoom International dial-in numbers: https://zoom.us/zoomconference
 * Meeting Recordings: [CDF Youtube Channel SIG Interoperability Playlist](https://www.youtube.com/playlist?list=PL2KXbZ9-EY9QxICOnONBFPn_cYfJ8BsaG)


### PR DESCRIPTION
According to our [calendar](https://calendar.google.com/calendar/embed?src=linuxfoundation.org_mhf0kmgedn67ihni8r129avp24%40group.calendar.google.com&ctz=America%2FLos_Angeles), the meetings take place at 17:00 UTC. 
This PR corrects the meeting time.