### PR TITLE
Add Andrea Frittoli to the members list

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ interoperability between tools
 * Ramin Akhbari ([@rakhbari](https://github.com/rakhbari)), eBay
 * Cameron Motevasselani ([@link108](https://github.com/link108)), Armory
 * Dave Sudia ([@thedevelopnik](https://github.com/thedevelopnik)), GoSpotCheck
+* Andrea Frittoli ([@afrittoli])(https://github.com/afrittoli)), IBM
 
 ## New Members
 


### PR DESCRIPTION
Andrea works on open source for IBM, he's one of the maintainers of Tekton
and member of the governance board. He implemented the cloud events
and he's interested make Tekton interoperable with other solution
in the CI/CD space.

He's been contributing to the events in CI/CD subgroup, and he's
interested in collaborating with the interoperability SIG in general.