### PR TITLE
Remove extra parenthesis in the URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ interoperability between tools
 * Ramin Akhbari ([@rakhbari](https://github.com/rakhbari)), eBay
 * Cameron Motevasselani ([@link108](https://github.com/link108)), Armory
 * Dave Sudia ([@thedevelopnik](https://github.com/thedevelopnik)), GoSpotCheck
-* Andrea Frittoli ([@afrittoli])(https://github.com/afrittoli)), IBM
+* Andrea Frittoli ([@afrittoli](https://github.com/afrittoli)), IBM
 
 ## New Members
 


### PR DESCRIPTION
Remove extra parenthesis in the URL that breaks the link to the github page for Andrea Frittoli