### PR TITLE
Placeholder for Standardized Metadata workstream

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ Workstream governance is documented [here](./docs/workstream-governance.md).
 Existing workstreams are
 
 * [Events in CI/CD](./workstreams/events_in_cicd/README.md)
+* [Standardized Metadata](./workstreams/standardized_metadata/README.md)
 
 ## Communication
 


### PR DESCRIPTION
This commit
- creates a folder for Standardized Metadata
- creates README.md file to connect it to the document on HackMD.io
- adds the workstream to SIG readme file