### PR TITLE
Update GitLab CI/CD definition on shared vocabulary list

### DIFF
--- a/docs/vocabulary.md
+++ b/docs/vocabulary.md
@@ -138,10 +138,10 @@ configured event occurs.
 
 ### GitLab CI/CD
 
-[GitLab CI/CD](https://docs.gitlab.com/ee/ci/introduction/) is a powerful tool
-built into GitLab that allows users to apply all the continuous methods
-(Continuous Integration, Delivery, and Deployment) to their software with no
-third-party application or integration needed.
+[GitLab CI/CD](https://docs.gitlab.com/ee/ci/introduction/) is a part of the 
+GitLab DevOps platform that allows users to apply all the continuous methods 
+(Continuous Integration, Delivery, and Deployment) to their software with 
+no third-party application or integration needed.
 
 Some of the core GitLab CI/CD terms are listed below. [[3]]
 


### PR DESCRIPTION
This PR is a recommendation from the GitLab team. GitLab CI/CD is not a tool in and of itself, but is part of GitLab, the DevOps platform.

This PR changes the language in the vocabulary file (https://github.com/cdfoundation/sig-interoperability/blob/master/docs/vocabulary.md) in the following way: 

From: 
> GitLab CI/CD is a powerful tool built into GitLab that allows users to apply all the continuous methods (Continuous Integration, Delivery, and Deployment) to their software with no third-party application or integration needed.

To: 
> GitLab CI/CD is a part of the GitLab DevOps platform that allows users to apply all the continuous methods (Continuous Integration, Delivery, and Deployment) to their software with no third-party application or integration needed.
