### PR TITLE
Add Software Supply Chain Stages to Pipeline Stage Terminology

### DIFF
--- a/docs/vocabulary.md
+++ b/docs/vocabulary.md
@@ -430,6 +430,13 @@ In the lists and table below, Software Artifacts includes: Documentation Source 
 * Outputs: Metadata, records, reports, logs, SBOM, source code of the primary OSS on internal/secure/trusted repository, source code of the dependencies on internal/secure/trusted repository, evaluation result/score based on organizational policies
 * Other Results and Side Effects: The Storage stage may also generate delta report for the dependencies of the primary OSS using the previously introduced version of the same OSS and the curent one. Additionally, this stage may also contribute to evaluation result/score based on the dependencies that go through OSS Introduction stage individually and if they are not adherent to organizational policies due to various reasons such as copyright/license and community health.
 
+#### OSS Consumption Stage
+* Semantics: Build primary OSS and its dependencies using their source code stored on internal/secure/trusted repositories on a secure build environment and store resulting signed artifacts/binaries on internal/secure/trusted repositories.
+* Aliases: Consume
+* Inputs: Internal URL to source code repository of the primary OSS, version of the primary OSS, Internal URL to source code repository of the dependencies
+* Outputs: Metadata, records, reports, logs, build BOM, signed artifacts/binaries
+* Other Results and Side Effects: The Consumption stage may also generate delta report using the build BOM of the previously build artifact and the build BOM of the current artifact.
+
 #### Build Stage
 * Semantics: Download, retrieve, assemble, and/or compile software into an executable and testable format. Download, retrieve, assemble, and/or compile documentation into a consumable format.
 * Aliases: Compile

--- a/docs/vocabulary.md
+++ b/docs/vocabulary.md
@@ -416,6 +416,13 @@ In the lists and table below, Software Artifacts includes: Documentation Source 
 * Inputs: Secrets, Pipeline Environment, Pipeline Workspace, Pipeline Utility Tools
 * Outputs: Stage Results and Return Codes, Logs
 
+#### OSS Introduction Stage
+* Semantics: Download open source software source code in order to analyze it to determine if it adheres to organizational policies from licensing, security, and compliance perspective.
+* Aliases: Introduce
+* Inputs: Public/Upstream URL to source code repository of the primary OSS, version of the primary OSS, Organizational Policies
+* Outputs: Metadata, records, logs, SBOM, evaluation result/score based on organizational policies
+* Other Results and Side Effects: The Introducation stage may also download community generated SBOM for the given version of the OSS if available, generate SBOM using the tools organization uses, generate statistics for determining community health (e.g., no of contributors, release frequency), analyze the primary OSS to identify its dependencies, identify license/copyright information, analyze software for vulnerabilities and malware, perform basic quality analysis. One or more of these outputs may contribute to final evaluation result/score and may result in blocking the introduction of the primary OSS.
+
 #### Build Stage
 * Semantics: Download, retrieve, assemble, and/or compile software into an executable and testable format. Download, retrieve, assemble, and/or compile documentation into a consumable format.
 * Aliases: Compile

--- a/docs/vocabulary.md
+++ b/docs/vocabulary.md
@@ -423,6 +423,13 @@ In the lists and table below, Software Artifacts includes: Documentation Source 
 * Outputs: Metadata, records, logs, SBOM, evaluation result/score based on organizational policies
 * Other Results and Side Effects: The Introducation stage may also download community generated SBOM for the given version of the OSS if available, generate SBOM using the tools organization uses, generate statistics for determining community health (e.g., no of contributors, release frequency), analyze the primary OSS to identify its dependencies, identify license/copyright information, analyze software for vulnerabilities and malware, perform basic quality analysis. One or more of these outputs may contribute to final evaluation result/score and may result in blocking the introduction of the primary OSS.
 
+#### OSS Storage Stage
+* Semantics: Download the source code of the primary OSS from its origin, analyze it for its dependencies, download the source code of the dependencies from their origin, and store them on internal/secure/trusted repositories for further activities as well as for making it available for consumption by the rest of the development organization.
+* Aliases: Store
+* Inputs: Public/Upstream URL to source code repository of the primary OSS, version of the primary OSS, Organizational Policies
+* Outputs: Metadata, records, reports, logs, SBOM, source code of the primary OSS on internal/secure/trusted repository, source code of the dependencies on internal/secure/trusted repository, evaluation result/score based on organizational policies
+* Other Results and Side Effects: The Storage stage may also generate delta report for the dependencies of the primary OSS using the previously introduced version of the same OSS and the curent one. Additionally, this stage may also contribute to evaluation result/score based on the dependencies that go through OSS Introduction stage individually and if they are not adherent to organizational policies due to various reasons such as copyright/license and community health.
+
 #### Build Stage
 * Semantics: Download, retrieve, assemble, and/or compile software into an executable and testable format. Download, retrieve, assemble, and/or compile documentation into a consumable format.
 * Aliases: Compile


### PR DESCRIPTION
CDF SIG Software Supply Chain started working on identifying pipeline
stages that may be employed by organizations to ensure the security
and compliance of the software they are consuming and producing.

This commit is the first commit in series, adding the first pipeline
stage, OSS Introduction Stage, in order to seek community feedback.

More information about this stage is available on SIG Software Supply
Chain PoC document:
https://hackmd.io/U6q685gFTdWRrkWZechvGw?view#OSS-Introduction