### PR TITLE
Updated the definition of Harness

### DIFF
--- a/docs/tools-terminology.md
+++ b/docs/tools-terminology.md
@@ -160,9 +160,7 @@ spin up or down as needed.
 
 ### Harness
 
-[Harness](https://harness.io/) is a Continuous Delivery as a Service platform 
-which enables confidence building orchestration and release strategies across a 
-multitude of platforms. 
+[Harness](https://harness.io/) is a modern software delivery platform which enables developers to fully automate and govern the build and deploy processes, with faster feedback loops thereby enhancing the developer experience.
 
 Some of the core Harness terms are listed below. [[15]]
 


### PR DESCRIPTION
Since years Harness have grown out of CD as-a-service and have included multiple modules to support the software delivery process, hence the olde definition doesn't holds.

